### PR TITLE
bugfix: limit SQL instance returned to match

### DIFF
--- a/RestoreSQLFromAzureRecoveryVault.ps1
+++ b/RestoreSQLFromAzureRecoveryVault.ps1
@@ -42,7 +42,7 @@
 
 .NOTES
     AUTHOR: Trey Troegel
-    LASTEDIT: July 13, 2020
+    LASTEDIT: Feb 03, 2023
 #>
 
 param
@@ -108,7 +108,7 @@ Write-Verbose –Message "Finding backup items from $($SourceBackupServerFQDN)"
 Write-Verbose –Message ""
 # There can be multiple database backups with the same name, but from different source servers registered in with vault. A common scenario would be the SQL system databases (master, msdb etc.).
 # Therefore, we need to filter Get-AzRecoveryServicesBackupItem by $SourceBackupServerFQDN in order to target the correct backup.
-$bkpItem = Get-AzRecoveryServicesBackupItem -BackupManagementType AzureWorkload -WorkloadType MSSQL -Name $BkupToRestore -VaultId $vault.ID | Where-Object ServerName -eq $SourceBackupServerFQDN
+$bkpItem = Get-AzRecoveryServicesBackupItem -BackupManagementType AzureWorkload -WorkloadType MSSQL -Name $BkupToRestore -VaultId $vault.ID | Where-Object ServerName -eq $SourceBackupServerFQDN | Where-Object {$_.Name.EndsWith(";$BkupToRestore")}
 
 $startDate = (Get-Date).AddDays(-14).ToUniversalTime()
 $endDate = (Get-Date).ToUniversalTime()


### PR DESCRIPTION
There was a bug here from Microsoft's end that would return a list of SQL instances if they are partial matches. For instance, this command when ran to retrieve database 'Test' will return a list if you have multiple databases called 'Test', 'TestTemp', 'TestDev'. The only way I found to fix this issue and keep it running on schedule is if we filter the returned result down again to only be the instance which ends in ";$BkupToRestore" (hence ensuring no prefix AND no postfix) . This worked for my case and I don't envision it would be a breaking change, just a bugfix.